### PR TITLE
Explicitly mentioned the number of partitions after each shuffle operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Investigating and benchmarking how partitioning of data on HDFS will affect Spar
 1. Build using the command - `mvn clean package`. It will create a tar.gz file named `Spark-Partitioning-0.1-SNAPSHOT.tar.gz` with the 4 directories `bin`, `etc`, `python` and `lib`.
 Copy the `tar.gz` file to the cluster and decompress the folder.
 
-2. To create random matrices and load them to HDFS, execute the shell script `./bin/load_data.sh ${ROW_LEFT} {COL_LEFT} ${ROW_RIGHT} ${COL_RIGHT} ${BASE_PATH}`.
+2. To create random matrices and load them to HDFS, execute the shell script `nohup ./bin/load_data.sh ${ROW_LEFT} {COL_LEFT} ${ROW_RIGHT} ${COL_RIGHT} ${BASE_PATH} > load_data.logs &`.
 
-3. To execute a particular experiment, execute the shell script `./bin/run_experiment.sh ${BASE_PATH} ${EXPERIMENT} ${NUM_OF_PARTITIONS}`.
-Allowed values for `${EXPERIMENT}` are `e1`, `e2` or `e3`. A file will be created with the name `job_${EXPERIMENT}_${PARTITIONS}.log`.
+3. To execute a particular experiment, execute the shell script `nohup ./bin/run_experiment.sh ${BASE_PATH} ${EXPERIMENT} ${NUM_OF_PARTITIONS} > job_${EXPERIMENT}_${PARTITIONS}.logs &`.
+Allowed values for `${EXPERIMENT}` are `e1`, `e2` or `e3`.
 
 **Code style notes**
 1. Python indentation and tabs = 4 spaces. (We are using Python 3)

--- a/src/main/bin/load_data.sh
+++ b/src/main/bin/load_data.sh
@@ -111,16 +111,19 @@ main() {
   rm "${PWD}"/right_matrix.txt
 
   # running the spark command to convert txt files to objectfiles
-  nohup spark-submit \
-    --class edu.asu.sparkpartitioning.TextToObjectFiles \
-    --master spark://172.31.19.91:7077 \
-    --deploy-mode client \
-    "${APP_HOME}"/lib/Spark-Partitioning-0.1-SNAPSHOT.jar \
-    hdfs://172.31.19.91:9000"${BASE_PATH}" \
-    hdfs://172.31.19.91:9000/spark/applicationHistory > parsing_logs.log
+  spark-submit \
+  --class edu.asu.sparkpartitioning.TextToObjectFiles \
+  --master spark://172.31.19.91:7077 \
+  --deploy-mode client \
+  "${APP_HOME}"/lib/Spark-Partitioning-0.1-SNAPSHOT.jar \
+  hdfs://172.31.19.91:9000"${BASE_PATH}" \
+  hdfs://172.31.19.91:9000/spark/applicationHistory > parsing_logs.log
 
-    hdfs dfs -rm -r "${BASE_PATH}"/raw/left
-    hdfs dfs -rm -r "${BASE_PATH}"/raw/right
+  # Forcing the replication to be 1
+  hdfs dfs -setrep -w 1 "${BASE_PATH}"
+
+  hdfs dfs -rm -r "${BASE_PATH}"/raw/left
+  hdfs dfs -rm -r "${BASE_PATH}"/raw/right
 }
 
 main "${@}"

--- a/src/main/bin/run_experiment.sh
+++ b/src/main/bin/run_experiment.sh
@@ -42,7 +42,7 @@ main() {
 	PARTITIONS=$3
 
 	# spark command for running an experiment
-	nohup spark-submit \
+	spark-submit \
 	--class edu.asu.sparkpartitioning.Main \
 	--master spark://172.31.19.91:7077 \
 	--deploy-mode client \

--- a/src/main/scala/edu/asu/sparkpartitioning/Main.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/Main.scala
@@ -3,9 +3,9 @@ package edu.asu.sparkpartitioning
 import edu.asu.sparkpartitioning.experiments.{E1, E2, E3}
 import edu.asu.sparkpartitioning.utils.MatrixOps.PairedOps
 import edu.asu.sparkpartitioning.utils.MatrixPartitioners.IndexedPartitioner
+import edu.asu.sparkpartitioning.utils.Parser.MatrixEntry
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.mllib.linalg.distributed.MatrixEntry
 import org.apache.spark.rdd.RDD
 
 object Main {
@@ -30,6 +30,7 @@ object Main {
     Logger.getLogger("com").setLevel(Level.WARN)
 
     implicit val log: Logger = Logger.getLogger("MatrixMultiplication")
+    System.setProperty("spark.hadoop.dfs.replication", "1")
 
     val conf = new SparkConf()
       .setAppName("matrix_multiplication")

--- a/src/main/scala/edu/asu/sparkpartitioning/TextToObjectFiles.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/TextToObjectFiles.scala
@@ -1,9 +1,8 @@
 package edu.asu.sparkpartitioning
 
-import edu.asu.sparkpartitioning.utils.Parser.readMatrix
+import edu.asu.sparkpartitioning.utils.Parser.{readMatrix, MatrixEntry}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.mllib.linalg.distributed.MatrixEntry
 import org.apache.spark.rdd.RDD
 
 object TextToObjectFiles {
@@ -23,6 +22,7 @@ object TextToObjectFiles {
     Logger.getLogger("org.apache").setLevel(Level.WARN)
     Logger.getLogger("akka").setLevel(Level.WARN)
     Logger.getLogger("com").setLevel(Level.WARN)
+    System.setProperty("spark.hadoop.dfs.replication", "1")
 
     val conf = new SparkConf()
       .setAppName("parsing_text_to_object_files")
@@ -33,9 +33,9 @@ object TextToObjectFiles {
 
     implicit val sc: SparkContext = new SparkContext(conf)
 
-    val left: RDD[(Long, (Long, Double))] = readMatrix(s"$basePath/raw/left")
+    val left: RDD[(Int, (Int, Double))] = readMatrix(s"$basePath/raw/left")
       .map({ case MatrixEntry(i, j, value) => (j, (i, value)) })
-    val right: RDD[(Long, (Long, Double))] = readMatrix(s"$basePath/raw/right")
+    val right: RDD[(Int, (Int, Double))] = readMatrix(s"$basePath/raw/right")
       .map({ case MatrixEntry(i, j, value) => (i, (j, value)) })
 
     left.saveAsObjectFile(s"$basePath/common/left")

--- a/src/main/scala/edu/asu/sparkpartitioning/experiments/E1.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/experiments/E1.scala
@@ -28,9 +28,10 @@ class E1(interNumParts: Int)(implicit sc: SparkContext) {
   def execute(basePath: String)(implicit log: Logger): Unit = {
 
     val (_, timeToDisk: Long) = timedBlock {
-      val left = sc.objectFile[(Long, (Long, Double))](s"$basePath/common/left")
+      val left =
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/common/left")
       val right =
-        sc.objectFile[(Long, (Long, Double))](s"$basePath/common/right")
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/common/right")
 
       left.saveAsObjectFile(s"$basePath/e1/left")
       right.saveAsObjectFile(s"$basePath/e1/right")
@@ -44,9 +45,9 @@ class E1(interNumParts: Int)(implicit sc: SparkContext) {
     )
 
     val (_, timeToMultiply: Long) = timedBlock {
-      val leftMat = sc.objectFile[(Long, (Long, Double))](s"$basePath/e1/left")
+      val leftMat = sc.objectFile[(Int, (Int, Double))](s"$basePath/e1/left")
       val rightMat =
-        sc.objectFile[(Long, (Long, Double))](s"$basePath/e1/right")
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/e1/right")
 
       val res = leftMat.multiply(rightMat, interNumParts)
 

--- a/src/main/scala/edu/asu/sparkpartitioning/experiments/E2.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/experiments/E2.scala
@@ -30,11 +30,11 @@ class E2(interNumParts: Int)(implicit sc: SparkContext) {
 
     val (_, timeToDisk: Long) = timedBlock {
       val left = sc
-        .objectFile[(Long, (Long, Double))](s"$basePath/common/left")
+        .objectFile[(Int, (Int, Double))](s"$basePath/common/left")
         .partitionBy(matPartitioner)
 
       val right = sc
-        .objectFile[(Long, (Long, Double))](s"$basePath/common/right")
+        .objectFile[(Int, (Int, Double))](s"$basePath/common/right")
         .partitionBy(matPartitioner)
 
       left.saveAsObjectFile(s"$basePath/e2/left")
@@ -50,9 +50,10 @@ class E2(interNumParts: Int)(implicit sc: SparkContext) {
     )
 
     val (_, timeToMultiply: Long) = timedBlock {
-      val leftMat = sc.objectFile[(Long, (Long, Double))](s"$basePath/e2/left")
+      val leftMat =
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/e2/left")
       val rightMat =
-        sc.objectFile[(Long, (Long, Double))](s"$basePath/e2/right")
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/e2/right")
 
       val res = leftMat.multiply(rightMat, interNumParts)
 

--- a/src/main/scala/edu/asu/sparkpartitioning/experiments/E3.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/experiments/E3.scala
@@ -29,9 +29,9 @@ class E3(interNumParts: Int)(implicit sc: SparkContext) {
   ): Unit = {
 
     val (_, timeToDisk: Long) = timedBlock {
-      val left = sc.objectFile[(Long, (Long, Double))](s"$basePath/common/left")
+      val left = sc.objectFile[(Int, (Int, Double))](s"$basePath/common/left")
       val right =
-        sc.objectFile[(Long, (Long, Double))](s"$basePath/common/right")
+        sc.objectFile[(Int, (Int, Double))](s"$basePath/common/right")
 
       left.saveAsObjectFile(s"$basePath/e3/left")
       right.saveAsObjectFile(s"$basePath/e3/right")
@@ -46,11 +46,11 @@ class E3(interNumParts: Int)(implicit sc: SparkContext) {
 
     val (_, timeToMultiply: Long) = timedBlock {
       val leftMat = sc
-        .objectFile[(Long, (Long, Double))](s"$basePath/e3/left")
+        .objectFile[(Int, (Int, Double))](s"$basePath/e3/left")
         .partitionBy(matPartitioner)
 
       val rightMat = sc
-        .objectFile[(Long, (Long, Double))](s"$basePath/e3/right")
+        .objectFile[(Int, (Int, Double))](s"$basePath/e3/right")
         .partitionBy(matPartitioner)
 
       val res = leftMat.multiply(rightMat, interNumParts)

--- a/src/main/scala/edu/asu/sparkpartitioning/utils/Parser.scala
+++ b/src/main/scala/edu/asu/sparkpartitioning/utils/Parser.scala
@@ -1,7 +1,6 @@
 package edu.asu.sparkpartitioning.utils
 
 import org.apache.spark.SparkContext
-import org.apache.spark.mllib.linalg.distributed.MatrixEntry
 import org.apache.spark.rdd.RDD
 
 object Parser {
@@ -11,7 +10,7 @@ object Parser {
    * format - row,column,value.
    *
    * @param path HDFS path to the text file
-   * @param sc [[SparkContext]]
+   * @param sc [[SparkContext]] the entry point to the app
    * @return [[RDD]] of [[MatrixEntry]]
    */
   def readMatrix(path: String)(implicit sc: SparkContext): RDD[MatrixEntry] = {
@@ -19,7 +18,16 @@ object Parser {
     val rddString: RDD[Array[String]] = textRDD.map(_.split(',').map(_.trim))
     rddString.map({
       case Array(row, col, value) =>
-        MatrixEntry(row.toLong, col.toLong, value.toDouble)
+        MatrixEntry(row.toInt, col.toInt, value.toDouble)
     })
   }
+
+  /**
+   *  Custom matrix entry case class
+   *
+   * @param i Row ID of the matrix
+   * @param j Column ID of the matrix
+   * @param value Cell Value
+   */
+  case class MatrixEntry(i: Int, j: Int, value: Double) extends Serializable
 }


### PR DESCRIPTION
1. Forced spark to use hdfs replication factor to 1
2. Row and Column IDs type changed from Long to Int
3. Removed nohup from the shell script, as nohup can be used easily from outside.
4. Explicitly mentioned the number of partitions after each shuffle operation in the multiplication operation.